### PR TITLE
fix for met histograms

### DIFF
--- a/src/AnalysisCMS.C
+++ b/src/AnalysisCMS.C
@@ -901,10 +901,11 @@ void AnalysisCMS::EventSetup(float jet_eta_max)
 
   ApplyWeights();
  
-  if (_is74X) 
-    GetMET(pfType1Met, pfType1Metphi);
-  else
-    GetMET(metPfType1, metPfType1Phi);
+  if (_is74X) {
+    metPfType1 = pfType1Met;
+    metPfType1Phi = pfType1Metphi;
+  }
+  GetMET(metPfType1, metPfType1Phi);
 
   GetTrkMET(metTtrk, metTtrkPhi);
 

--- a/src/AnalysisStop.C
+++ b/src/AnalysisStop.C
@@ -68,7 +68,7 @@ void AnalysisStop::Loop(TString analysis, TString filename, float luminosity)
 
   // Loop over events
   //----------------------------------------------------------------------------
-  for (Long64_t jentry=0; jentry<1000/*_nentries*/;jentry++) {
+  for (Long64_t jentry=0; jentry<_nentries;jentry++) {
 
     Long64_t ientry = LoadTree(jentry);
 

--- a/src/AnalysisStop.C
+++ b/src/AnalysisStop.C
@@ -68,7 +68,7 @@ void AnalysisStop::Loop(TString analysis, TString filename, float luminosity)
 
   // Loop over events
   //----------------------------------------------------------------------------
-  for (Long64_t jentry=0; jentry<_nentries;jentry++) {
+  for (Long64_t jentry=0; jentry<1000/*_nentries*/;jentry++) {
 
     Long64_t ientry = LoadTree(jentry);
 


### PR DESCRIPTION
- I  fixed the usage of the met variables in 74X trees so that not it's used also for filling the met histogram and not only the vector MET. The change should be straightforward, but note that I didn't test it because of the issue with the queue in gridui
- The change in AnalysisStop is only to correct an unintentional previous commit 
