### PR TITLE
b-tag working points for 80X (as 76X, anyway)

### DIFF
--- a/include/BTagWorkingPoints80X.h
+++ b/include/BTagWorkingPoints80X.h
@@ -1,0 +1,16 @@
+
+
+
+// https://twiki.cern.ch/twiki/bin/view/CMS/BtagRecommendation80X
+// pfCombinedMVAV2BJetTags
+const double cMVAv2L = -0.715;
+const double cMVAv2M =  0.185;
+const double cMVAv2T =  0.875;
+
+
+// https://twiki.cern.ch/twiki/bin/view/CMS/BtagRecommendation80X
+// pfCombinedInclusiveSecondaryVertexV2BJetTags
+const double CSVv2L = 0.460;
+const double CSVv2M = 0.800;
+const double CSVv2T = 0.935;
+

--- a/include/Constants.h
+++ b/include/Constants.h
@@ -12,7 +12,8 @@
 //#include "CutsWZ.h"
 
 //#include "BTagWorkingPoints74X.h"
-#include "BTagWorkingPoints76X.h"
+//#include "BTagWorkingPoints76X.h"
+#include "BTagWorkingPoints80X.h"
 
 
 const double lumi_fb_2016       = 6.324;  // 2016B + 2016C


### PR DESCRIPTION
Cloned include/BTagWorkingPoints76X.h to include/BTagWorkingPoints80X.h
