### PR TITLE
Tools to allow AnalysisStop to save specific analysis histograms for each systematic at one time

### DIFF
--- a/include/AnalysisStop.h
+++ b/include/AnalysisStop.h
@@ -15,14 +15,21 @@ class AnalysisStop : public AnalysisCMS
 
   void BookAnalysisHistograms(); 
 
+  void BookSystematicHistograms(); 
+
   void GetAnalysisVariables(); 
 
   void FillAnalysisHistograms(int     ichannel,
 			      int     icut,
-			      int     ijet);
+			      int     ijet); 
+
+  void FillSystematicHistograms(int     ichannel,
+				int     icut);
 
   void FillLevelHistograms   (int     icut,
 			      bool    pass);
+
+  void SaveSystematicHistograms();
 
   void Loop                  (TString analysis,
 			      TString sample,
@@ -58,7 +65,7 @@ class AnalysisStop : public AnalysisCMS
   TH1D*                  h_mlb2true         [nchannel][ncut][njetbin+1];
   TH2D*                  h_mt2lblbvsmlbtrue [nchannel][ncut][njetbin+1];
 
-  bool _FillAllHistograms;
+  int _SaveHistograms;
 
   float _metmeff, _MT2ll;
   TH1D*                  h_metmeff          [nchannel][ncut][njetbin+1];
@@ -79,6 +86,10 @@ class AnalysisStop : public AnalysisCMS
   float _R2_Met; int NbinsR2 = 7;
   float vMinR2 = 0., vMaxR2 = 1.4;
   TH1D*                  h_R2_Met           [nchannel][ncut][njetbin+1];
+
+  // Systematic output
+  TFile*                 root_output_systematic[nsystematic];
+  TH1F*                  h_MT2ll_systematic [nchannel][ncut][nsystematic];
   
 };
 

--- a/include/Constants.h
+++ b/include/Constants.h
@@ -1,3 +1,4 @@
+
 #if !defined(MYLIB_CONSTANTS_H)
 #define MYLIB_CONSTANTS_H 1
 
@@ -53,12 +54,16 @@ enum {
   METup,
   Btagdo,
   Btagup,
+  BtagFSdo,
+  BtagFSup,
   Idisodo,
   Idisoup,
   Triggerdo,
   Triggerup,
   Recodo,
   Recoup,
+  Fastsimdo,
+  Fastsimup,
   nsystematic  // This line should be always last
 };
 
@@ -74,12 +79,40 @@ const TString ssystematic[nsystematic] = {
   "METup",
   "Btagdo",
   "Btagup",
+  "BtagFSdo",
+  "BtagFSup",
   "Idisodo",
   "Idisoup",
   "Triggerdo",
   "Triggerup",
   "Recodo",
-  "Recoup"
+  "Recoup",
+  "Fastsimdo",
+  "Fastsimup"
+};
+
+const bool systematicfromweight[nsystematic] = {
+  true,
+  false,
+  false,
+  false,
+  false,
+  false,
+  false,
+  false,
+  false,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true
 };
 
 

--- a/runAnalysisMiniTrees.C
+++ b/runAnalysisMiniTrees.C
@@ -13,7 +13,7 @@
 
 void runAnalysisMiniTrees(TString filename,
 			  TString systematic,
-			  int     FillAllHistograms = 1,
+			  int     SaveHistograms    =  0,
 			  float   StopMass          = -1.,
 			  float   NeutralinoMass    = -1.)
 {
@@ -29,7 +29,7 @@ void runAnalysisMiniTrees(TString filename,
   //  AnalysisMonoH   analysis(latino, systematic); analysis.Loop("MonoH",   filename, baseW_lumi_fb);
   //  AnalysisPR      analysis(latino, systematic); analysis.Loop("PR",      filename, baseW_lumi_fb);
   //  AnalysisShape   analysis(latino, systematic); analysis.Loop("Shape",   filename, baseW_lumi_fb);
-  AnalysisStop    analysis(file, systematic, FillAllHistograms); analysis.Loop("Stop", filename, baseW_lumi_fb, StopMass, NeutralinoMass);
+  AnalysisStop    analysis(file, systematic, SaveHistograms); analysis.Loop("Stop", filename, baseW_lumi_fb, StopMass, NeutralinoMass);
   //  AnalysisTop     analysis(latino, systematic); analysis.Loop("Top",     filename, baseW_lumi_fb);
   //  AnalysisTTDM    analysis(latino, systematic); analysis.Loop("TTDM",    filename, baseW_lumi_fb);
   //  AnalysisWW      analysis(latino, systematic); analysis.Loop("WW",      filename, baseW_lumi_fb);


### PR DESCRIPTION
Running AnalysisCMS for each systematic to have all the systematic variations is tedious. For the systematics for which we compute a weight this can be avoided. I introduces a parameter in AnalysisStop, called SaveHistograms, to tell the code what histograms to fill and save. Its value can be:
0 - to make all the histograms specified in AnalysisCMS and  the analysis specific ones added in AnalysisStop (using the systematic flag passed by submit-jobs.sh) 
1 - to make only the analysis specific histograms (using the systematic flag passed by submit-jobs.sh) 
2 - to make the analysis specific histograms (using the systematic flag passed by submit-jobs.sh)  and a set of systematic histograms (in the present implementation just one, a subset of 1) for the other systematics for which we compute a weight.

When running on full latinos trees, SaveHistograms is set to 0 for "nominal" and to 1 for the other systematics. When running on minitrees, it can be set thorught the sample list. 

 