### PR TITLE
fix bug on third lepton veto + update MET filter recommendations

### DIFF
--- a/include/AnalysisCMS.h
+++ b/include/AnalysisCMS.h
@@ -395,7 +395,6 @@ class AnalysisCMS : public AnalysisBase
   unsigned int           _jetbin;
   unsigned int           _nelectron;
   unsigned int           _nlepton;
-  unsigned int           _ntightlepton;
   
   ofstream               txt_eventdump;
   ofstream               txt_summary;

--- a/include/AnalysisCMS.h
+++ b/include/AnalysisCMS.h
@@ -98,7 +98,7 @@ class AnalysisCMS : public AnalysisBase
   bool        PassTrigger       ();
 
   bool        ApplyMETFilters   (bool     ApplyGiovanniFilters        = false, 
-				 bool     ApplyICHEPAdditionalFilters = false);
+				 bool     ApplyICHEPAdditionalFilters = true);
 
   void        PrintProgress     (Long64_t counter,
 				 Long64_t total);
@@ -395,6 +395,7 @@ class AnalysisCMS : public AnalysisBase
   unsigned int           _jetbin;
   unsigned int           _nelectron;
   unsigned int           _nlepton;
+  unsigned int           _ntightlepton;
   
   ofstream               txt_eventdump;
   ofstream               txt_summary;

--- a/src/AnalysisStop.C
+++ b/src/AnalysisStop.C
@@ -109,7 +109,7 @@ void AnalysisStop::Loop(TString analysis, TString filename, float luminosity, fl
 
     if (!_isminitree) {
 
-      if ( ! _nlepton == 2) continue; // 2 and only 2 leptons
+      if (_nlepton != 2) continue; // 2 and only 2 leptons
 
       if (_ismc) CorrectEventWeight(); 
   


### PR DESCRIPTION
- !_nlepton==2 is not the same as _nlepton!=2

- Now MET recommends to apply the "ICHEP additional" filters: https://twiki.cern.ch/twiki/bin/view/CMS/MissingETOptionalFiltersRun2#Moriond_2017